### PR TITLE
Adds functionality for Broken mods folder

### DIFF
--- a/Core/ModDetail.cs
+++ b/Core/ModDetail.cs
@@ -7,6 +7,7 @@
         public string filepath;
         public string downloadUrl;
         public string hash;
+        public int approvalStatus;
 
         public ModDetail(string name, string version, string filepath)
         {
@@ -30,6 +31,15 @@
             this.filepath = filepath;
             this.downloadUrl = downloadUrl;
             this.hash = hash;
+        }
+
+        public ModDetail(string name, string version, string downloadUrl, string hash, int approvalStatus)
+        {
+            this.name = name;
+            this.version = version;
+            this.downloadUrl = downloadUrl;
+            this.hash = hash;
+            this.approvalStatus = approvalStatus;
         }
     }
 }

--- a/Core/VRCModUpdaterCore.cs
+++ b/Core/VRCModUpdaterCore.cs
@@ -29,12 +29,16 @@ namespace VRCModUpdater.Core
 
         private static Dictionary<string, ModDetail> remoteMods = new Dictionary<string, ModDetail>();
         private static Dictionary<string, ModDetail> installedMods = new Dictionary<string, ModDetail>();
+        private static Dictionary<string, ModDetail> brokenMods = new Dictionary<string, ModDetail>();
+
 
         public static string currentStatus = "", tmpCurrentStatus = "";
         public static int progressTotal = 0, progressDownload = 0;
         private static int tmpProgressTotal = 0, tmpProgressDownload = 0;
 
         private static int toUpdateCount = 0;
+        private static int toBrokenCount = 0;
+        private static int toModsCount = 0;
 
         private static List<FailedUpdateInfo> failedUpdates = new List<FailedUpdateInfo>();
 
@@ -128,7 +132,9 @@ namespace VRCModUpdater.Core
             APIMod[] apiMods = JsonConvert.DeserializeObject<APIMod[]>(apiResponse);
 
             remoteMods.Clear();
-            
+
+            int verifiedModsCount = 0;
+
             foreach (APIMod mod in apiMods)
             {
                 if (mod.versions.Length == 0)
@@ -136,86 +142,89 @@ namespace VRCModUpdater.Core
 
                 APIModVersion versionDetails = mod.versions[0];
 
-                if (versionDetails.ApprovalStatus != 1)
-                    continue;
-
                 // Aliases
                 foreach (string alias in mod.aliases)
                     if (alias != versionDetails.name)
                         oldToNewModNames[alias] = versionDetails.name;
 
                 // Add to known mods
-                remoteMods.Add(versionDetails.name, new ModDetail(versionDetails.name, versionDetails.modversion, versionDetails.downloadlink, versionDetails.hash));
+                if (versionDetails.ApprovalStatus == 1)
+                    verifiedModsCount++;
+                remoteMods.Add(versionDetails.name, new ModDetail(versionDetails.name, versionDetails.modversion, versionDetails.downloadlink, versionDetails.hash, versionDetails.ApprovalStatus));
             }
 
-            MelonLogger.Msg("API returned " + apiMods.Length + " mods, including " + remoteMods.Count + " verified mods");
+            MelonLogger.Msg("API returned " + apiMods.Length + " mods, including " + verifiedModsCount + " verified mods");
         }
 
         private static void ScanModFolder()
         {
-            installedMods.Clear();
+            var list = new [] { installedMods, brokenMods };
+            var runOnce = false;
+            foreach (var dict in list)
+            {   //This is a kinda dirty way to do this
+                dict.Clear();
+                string basedirectory = !runOnce ? MelonHandler.ModsDirectory : MelonHandler.ModsDirectory + "/Broken";
 
-            string basedirectory = MelonHandler.ModsDirectory;
-
-            string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
-            if (dlltbl.Length > 0)
-            {
-                for (int i = 0; i < dlltbl.Length; i++)
+                string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
+                if (dlltbl.Length > 0)
                 {
-                    string filename = dlltbl[i];
-                    if (string.IsNullOrEmpty(filename))
-                        continue;
-
-                    if (filename.EndsWith(".dev.dll"))
-                        continue;
-
-                    try
+                    for (int i = 0; i < dlltbl.Length; i++)
                     {
-                        string modName;
-                        string modVersion;
-                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(filename, new ReaderParameters { ReadWrite = true }))
-                        {
-
-                            CustomAttribute melonInfoAttribute = assembly.CustomAttributes.FirstOrDefault(a =>
-                                a.AttributeType.Name == "MelonModInfoAttribute" || a.AttributeType.Name == "MelonInfoAttribute");
-
-                            if (melonInfoAttribute == null)
-                                continue;
-
-                            modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
-                            modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
-                        }
-
-                        modName = GetNewModName(modName); // Backward mod compatibility
-
-                        if (installedMods.TryGetValue(modName, out ModDetail installedModDetail))
-                        {
-                            if (VersionUtils.CompareVersion(installedModDetail.version, modVersion) > 0)
-                            {
-                                File.Delete(filename); // Delete duplicated mods
-                                MelonLogger.Msg("Deleted duplicated mod " + modName);
-                            }
-                            else
-                            {
-                                File.Delete(installedModDetail.filepath); // Delete duplicated mods
-                                MelonLogger.Msg("Deleted duplicated mod " + modName);
-                                installedMods[modName] = new ModDetail(modName, modVersion, filename);
-                            }
-
+                        string filename = dlltbl[i];
+                        if (string.IsNullOrEmpty(filename))
                             continue;
-                        }
 
-                        installedMods.Add(modName, new ModDetail(modName, modVersion, filename));
-                    }
-                    catch (Exception)
-                    {
-                        MelonLogger.Msg("Failed to read assembly " + filename);
+                        if (filename.EndsWith(".dev.dll"))
+                            continue;
+
+                        try
+                        {
+                            string modName;
+                            string modVersion;
+                            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(filename, new ReaderParameters { ReadWrite = true }))
+                            {
+
+                                CustomAttribute melonInfoAttribute = assembly.CustomAttributes.FirstOrDefault(a =>
+                                    a.AttributeType.Name == "MelonModInfoAttribute" || a.AttributeType.Name == "MelonInfoAttribute");
+
+                                if (melonInfoAttribute == null)
+                                    continue;
+
+                                modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
+                                modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
+                            }
+
+                            modName = GetNewModName(modName); // Backward mod compatibility
+
+                            if (dict.TryGetValue(modName, out ModDetail installedModDetail))
+                            {
+                                if (VersionUtils.CompareVersion(installedModDetail.version, modVersion) > 0)
+                                {
+                                    File.Delete(filename); // Delete duplicated mods
+                                    MelonLogger.Msg("Deleted duplicated mod " + modName);
+                                }
+                                else
+                                {
+                                    File.Delete(installedModDetail.filepath); // Delete duplicated mods
+                                    MelonLogger.Msg("Deleted duplicated mod " + modName);
+                                    dict[modName] = new ModDetail(modName, modVersion, filename);
+                                }
+
+                                continue;
+                            }
+
+                            dict.Add(modName, new ModDetail(modName, modVersion, filename));
+                        }
+                        catch (Exception)
+                        {
+                            MelonLogger.Msg("Failed to read assembly " + filename);
+                        }
                     }
                 }
+                MelonLogger.Msg("Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
+                runOnce = true;
             }
-
-            MelonLogger.Msg("Found " + installedMods.Count + " unique non-dev mods installed");
-        }
+        }  
 
         private static string GetNewModName(string currentName)
         {
@@ -233,28 +242,100 @@ namespace VRCModUpdater.Core
 
         private static void DownloadAndUpdateMods()
         {
+            List<ModDetail> toMods = new List<ModDetail>();
+            List<ModDetail> toBroken = new List<ModDetail>();
             List<ModDetail> toUpdate = new List<ModDetail>();
 
-            // List all installed mods that can be updated
-            foreach (KeyValuePair<string, ModDetail> installedMod in installedMods)
+            // Check for broken mods with updates
+            foreach (KeyValuePair<string, ModDetail> brokenMod in brokenMods)
             {
-                VersionUtils.VersionData installedModVersion = VersionUtils.GetVersion(installedMod.Value.version);
-                foreach (KeyValuePair<string, ModDetail> remoteMod in remoteMods)
+                if (remoteMods.TryGetValue(brokenMod.Key, out ModDetail remoteMod))
                 {
-                    if (installedMod.Key == remoteMod.Key)
-                    {
-                        VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.Value.version);
-                        int compareResult = VersionUtils.CompareVersion(remoteModVersion, installedModVersion);
-                        MelonLogger.Msg("(Mod: " + remoteMod.Key + ") version compare between [remote] " + remoteMod.Value.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
-                        if (compareResult > 0)
-                            toUpdate.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.Value.downloadUrl, remoteMod.Value.hash));
+                    if (remoteMod.approvalStatus != 1)
+                        continue;
 
-                        break;
-                    }
+                    VersionUtils.VersionData brokenModVersion = VersionUtils.GetVersion(brokenMod.Value.version);
+                    VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
+                    int compareResult = VersionUtils.CompareVersion(remoteModVersion, brokenModVersion);
+                    
+                    MelonLogger.Msg("(Broken Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + brokenMod.Value.version + ": " + compareResult);
+                    if (compareResult > 0) // Don't move from broken unless new version > old
+                        toMods.Add(new ModDetail(brokenMod.Key, brokenMod.Value.version, brokenMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    continue;
                 }
             }
 
-            MelonLogger.Msg("Found " + toUpdate.Count + " outdated mods");
+            // List all installed mods that can be updated or moved to broken
+            foreach (KeyValuePair<string, ModDetail> installedMod in installedMods)
+            {
+                if (remoteMods.TryGetValue(installedMod.Key, out ModDetail remoteMod))
+                {
+                    VersionUtils.VersionData installedModVersion = VersionUtils.GetVersion(installedMod.Value.version);
+                    VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
+                    int compareResult = VersionUtils.CompareVersion(remoteModVersion, installedModVersion);
+
+                    if(remoteMod.approvalStatus != 1)
+                    {
+                        MelonLogger.Msg($"(Mod: {installedMod.Key}) Remote Approval Status: Broken/Other - {remoteMod.approvalStatus}");
+                        if (compareResult >= 0) // Don't move to broken if local version is higher than remote
+                            toBroken.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath));
+                        else
+                            MelonLogger.Msg($"Ignoring as local version is higer than remote. Remote: {remoteMod.version}, Local: {installedMod.Value.version}");
+                        continue;
+                    }
+                    MelonLogger.Msg("(Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
+                    if (compareResult > 0)
+                        toUpdate.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    continue;
+                }
+            }
+
+            MelonLogger.Msg("Found " + toUpdate.Count + " outdated mods | " + toBroken.Count + " broken mods | " + toMods.Count + " fixed mods");
+
+            toModsCount = toMods.Count;
+            for (int i = 0; i < toModsCount; ++i)
+            {
+                ModDetail mod = toMods[i];
+                MelonLogger.Warning(mod.name + "Moving to Mods from Broken folder");
+                try
+                {
+                    if (File.Exists(mod.filepath))
+                    {
+                        var newDir = Directory.GetParent(Path.GetDirectoryName(mod.filepath)) + "/" + Path.GetFileName(mod.filepath);       
+                        toUpdate.Add(new ModDetail(mod.name, mod.version, newDir, mod.downloadUrl, mod.hash));
+                        File.Delete(mod.filepath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    MelonLogger.Error("Failed to updated fixed mod" + mod.filepath + ":\n" + e);
+                }
+            }
+
+            toBrokenCount = toBroken.Count;
+            for (int i = 0; i < toBrokenCount; ++i)
+            {
+                ModDetail mod = toBroken[i];
+                MelonLogger.Warning(mod.name + " - Moving to Broken folder");
+                try
+                {
+                    if (File.Exists(mod.filepath))
+                    {
+                        var newDir = Path.GetDirectoryName(mod.filepath) + "/Broken";
+                        if(!Directory.Exists(newDir))
+                            Directory.CreateDirectory(newDir);
+                        var newFilePath = newDir + "/" + Path.GetFileName(mod.filepath);
+                        if (!File.Exists(newFilePath))
+                            File.Move(mod.filepath, newFilePath);
+                        else
+                            File.Delete(mod.filepath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    MelonLogger.Error("Failed to move mod to broken folder" + mod.filepath + ":\n" + e);
+                }
+            }
 
             toUpdateCount = toUpdate.Count;
             for (int i = 0; i < toUpdateCount; ++i)


### PR DESCRIPTION
Allows the updater to moves mods to and from the Broken mods folder (also made by VRCMelonAssistant)
* It will move any mods that are flagged as broken by the Remote API to the Broken folder as long as the local version is not newer then the remote version. (Allows modders to locally test new versions)
* Will move any mods that are in the Broken folder to Mods if the remote API says it is Approved and remote version is > local (Allows someone to manually move a mod to the broken folder if not flagged by the API and still auto update when the next version comes out)
* Has a MelonPref to disable the moving To/From Broken folder completely

![image](https://user-images.githubusercontent.com/81605232/156486332-dc435aa9-ee23-4e8b-aae5-b8876cff6065.png)
