### PR TITLE
Bugfixes and Popup/Caching features

### DIFF
--- a/Core/ModDetail.cs
+++ b/Core/ModDetail.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace VRCModUpdater.Core
+﻿namespace VRCModUpdater.Core
 {
     public class ModDetail
     {
@@ -11,10 +10,6 @@ namespace VRCModUpdater.Core
         public int approvalStatus;
         public string[] dependencies = new string[0];
         public string[] optDependencies = new string[0];
-        public DateTime lastMod;
-        public DateTime lastAccess;
-
-        ModDetail() { }
 
         public ModDetail(string name, string version, string filepath)
         {
@@ -30,17 +25,6 @@ namespace VRCModUpdater.Core
             this.filepath = filepath;
             this.dependencies = dependencies;
             this.optDependencies = optDependencies;
-        }
-
-        public ModDetail(string name, string version, string filepath, string[] dependencies, string[] optDependencies, DateTime lastMod, DateTime lastAccess)
-        {
-            this.name = name;
-            this.version = version;
-            this.filepath = filepath;
-            this.dependencies = dependencies;
-            this.optDependencies = optDependencies;
-            this.lastMod = lastMod;
-            this.lastAccess = lastAccess;
         }
 
         public ModDetail(string name, string version, string downloadUrl, string hash)

--- a/Core/ModDetail.cs
+++ b/Core/ModDetail.cs
@@ -7,6 +7,7 @@
         public string filepath;
         public string downloadUrl;
         public string hash;
+        public int approvalStatus;
 
         public ModDetail(string name, string version, string filepath)
         {
@@ -30,6 +31,15 @@
             this.filepath = filepath;
             this.downloadUrl = downloadUrl;
             this.hash = hash;
+        }
+
+        public ModDetail(string name, string version, string downloadUrl, string hash, int approvalStatus)
+        {
+            this.name = name;
+            this.version = version;
+            this.downloadUrl = downloadUrl;
+            this.hash = hash;
+            this.approvalStatus = approvalStatus;
         }
     }
 }

--- a/Core/ModDetail.cs
+++ b/Core/ModDetail.cs
@@ -8,12 +8,23 @@
         public string downloadUrl;
         public string hash;
         public int approvalStatus;
+        public string[] dependencies = new string[0];
+        public string[] optDependencies = new string[0];
 
         public ModDetail(string name, string version, string filepath)
         {
             this.name = name;
             this.version = version;
             this.filepath = filepath;
+        }
+
+        public ModDetail(string name, string version, string filepath, string[] dependencies, string[] optDependencies)
+        {
+            this.name = name;
+            this.version = version;
+            this.filepath = filepath;
+            this.dependencies = dependencies;
+            this.optDependencies = optDependencies;
         }
 
         public ModDetail(string name, string version, string downloadUrl, string hash)

--- a/Core/ModDetail.cs
+++ b/Core/ModDetail.cs
@@ -1,4 +1,5 @@
-﻿namespace VRCModUpdater.Core
+﻿using System;
+namespace VRCModUpdater.Core
 {
     public class ModDetail
     {
@@ -10,6 +11,10 @@
         public int approvalStatus;
         public string[] dependencies = new string[0];
         public string[] optDependencies = new string[0];
+        public DateTime lastMod;
+        public DateTime lastAccess;
+
+        ModDetail() { }
 
         public ModDetail(string name, string version, string filepath)
         {
@@ -25,6 +30,17 @@
             this.filepath = filepath;
             this.dependencies = dependencies;
             this.optDependencies = optDependencies;
+        }
+
+        public ModDetail(string name, string version, string filepath, string[] dependencies, string[] optDependencies, DateTime lastMod, DateTime lastAccess)
+        {
+            this.name = name;
+            this.version = version;
+            this.filepath = filepath;
+            this.dependencies = dependencies;
+            this.optDependencies = optDependencies;
+            this.lastMod = lastMod;
+            this.lastAccess = lastAccess;
         }
 
         public ModDetail(string name, string version, string downloadUrl, string hash)

--- a/Core/Utils/VersionUtils.cs
+++ b/Core/Utils/VersionUtils.cs
@@ -46,7 +46,7 @@ namespace VRCModUpdater.Core.Utils
 
             MatchCollection matches = Regex.Matches(versionString, "\\d+");
             bool isValidSemver = Regex.IsMatch(versionString, "^v?[0-9][\\d.-_]*[^\\s]*$");
-            MelonLoader.MelonLogger.Msg($"SEMVER \"{versionString}\": {isValidSemver}");
+            //MelonLoader.MelonLogger.Msg($"SEMVER \"{versionString}\": {isValidSemver}");
 
             return new VersionData(matches, isValidSemver);
         }

--- a/Core/VRCModUpdaterCore.cs
+++ b/Core/VRCModUpdaterCore.cs
@@ -29,12 +29,16 @@ namespace VRCModUpdater.Core
 
         private static Dictionary<string, ModDetail> remoteMods = new Dictionary<string, ModDetail>();
         private static Dictionary<string, ModDetail> installedMods = new Dictionary<string, ModDetail>();
+        private static Dictionary<string, ModDetail> brokenMods = new Dictionary<string, ModDetail>();
+
 
         public static string currentStatus = "", tmpCurrentStatus = "";
         public static int progressTotal = 0, progressDownload = 0;
         private static int tmpProgressTotal = 0, tmpProgressDownload = 0;
 
         private static int toUpdateCount = 0;
+        private static int toBrokenCount = 0;
+        private static int toModsCount = 0;
 
         private static List<FailedUpdateInfo> failedUpdates = new List<FailedUpdateInfo>();
 
@@ -128,7 +132,9 @@ namespace VRCModUpdater.Core
             APIMod[] apiMods = JsonConvert.DeserializeObject<APIMod[]>(apiResponse);
 
             remoteMods.Clear();
-            
+
+            int verifiedModsCount = 0;
+
             foreach (APIMod mod in apiMods)
             {
                 if (mod.versions.Length == 0)
@@ -136,86 +142,89 @@ namespace VRCModUpdater.Core
 
                 APIModVersion versionDetails = mod.versions[0];
 
-                if (versionDetails.ApprovalStatus != 1)
-                    continue;
-
                 // Aliases
                 foreach (string alias in mod.aliases)
                     if (alias != versionDetails.name)
                         oldToNewModNames[alias] = versionDetails.name;
 
                 // Add to known mods
-                remoteMods.Add(versionDetails.name, new ModDetail(versionDetails.name, versionDetails.modversion, versionDetails.downloadlink, versionDetails.hash));
+                if (versionDetails.ApprovalStatus == 1)
+                    verifiedModsCount++;
+                remoteMods.Add(versionDetails.name, new ModDetail(versionDetails.name, versionDetails.modversion, versionDetails.downloadlink, versionDetails.hash, versionDetails.ApprovalStatus));
             }
 
-            MelonLogger.Msg("API returned " + apiMods.Length + " mods, including " + remoteMods.Count + " verified mods");
+            MelonLogger.Msg("API returned " + apiMods.Length + " mods, including " + verifiedModsCount + " verified mods");
         }
 
         private static void ScanModFolder()
         {
-            installedMods.Clear();
+            var list = new [] { installedMods, brokenMods };
+            var runOnce = false;
+            foreach (var dict in list)
+            {   //This is a kinda dirty way to do this
+                dict.Clear();
+                string basedirectory = !runOnce ? MelonHandler.ModsDirectory : MelonHandler.ModsDirectory + "/Broken";
 
-            string basedirectory = MelonHandler.ModsDirectory;
-
-            string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
-            if (dlltbl.Length > 0)
-            {
-                for (int i = 0; i < dlltbl.Length; i++)
+                string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
+                if (dlltbl.Length > 0)
                 {
-                    string filename = dlltbl[i];
-                    if (string.IsNullOrEmpty(filename))
-                        continue;
-
-                    if (filename.EndsWith(".dev.dll"))
-                        continue;
-
-                    try
+                    for (int i = 0; i < dlltbl.Length; i++)
                     {
-                        string modName;
-                        string modVersion;
-                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(filename, new ReaderParameters { ReadWrite = true }))
-                        {
-
-                            CustomAttribute melonInfoAttribute = assembly.CustomAttributes.FirstOrDefault(a =>
-                                a.AttributeType.Name == "MelonModInfoAttribute" || a.AttributeType.Name == "MelonInfoAttribute");
-
-                            if (melonInfoAttribute == null)
-                                continue;
-
-                            modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
-                            modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
-                        }
-
-                        modName = GetNewModName(modName); // Backward mod compatibility
-
-                        if (installedMods.TryGetValue(modName, out ModDetail installedModDetail))
-                        {
-                            if (VersionUtils.CompareVersion(installedModDetail.version, modVersion) > 0)
-                            {
-                                File.Delete(filename); // Delete duplicated mods
-                                MelonLogger.Msg("Deleted duplicated mod " + modName);
-                            }
-                            else
-                            {
-                                File.Delete(installedModDetail.filepath); // Delete duplicated mods
-                                MelonLogger.Msg("Deleted duplicated mod " + modName);
-                                installedMods[modName] = new ModDetail(modName, modVersion, filename);
-                            }
-
+                        string filename = dlltbl[i];
+                        if (string.IsNullOrEmpty(filename))
                             continue;
-                        }
 
-                        installedMods.Add(modName, new ModDetail(modName, modVersion, filename));
-                    }
-                    catch (Exception)
-                    {
-                        MelonLogger.Msg("Failed to read assembly " + filename);
+                        if (filename.EndsWith(".dev.dll"))
+                            continue;
+
+                        try
+                        {
+                            string modName;
+                            string modVersion;
+                            using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(filename, new ReaderParameters { ReadWrite = true }))
+                            {
+
+                                CustomAttribute melonInfoAttribute = assembly.CustomAttributes.FirstOrDefault(a =>
+                                    a.AttributeType.Name == "MelonModInfoAttribute" || a.AttributeType.Name == "MelonInfoAttribute");
+
+                                if (melonInfoAttribute == null)
+                                    continue;
+
+                                modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
+                                modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
+                            }
+
+                            modName = GetNewModName(modName); // Backward mod compatibility
+
+                            if (dict.TryGetValue(modName, out ModDetail installedModDetail))
+                            {
+                                if (VersionUtils.CompareVersion(installedModDetail.version, modVersion) > 0)
+                                {
+                                    File.Delete(filename); // Delete duplicated mods
+                                    MelonLogger.Msg("Deleted duplicated mod " + modName);
+                                }
+                                else
+                                {
+                                    File.Delete(installedModDetail.filepath); // Delete duplicated mods
+                                    MelonLogger.Msg("Deleted duplicated mod " + modName);
+                                    dict[modName] = new ModDetail(modName, modVersion, filename);
+                                }
+
+                                continue;
+                            }
+
+                            dict.Add(modName, new ModDetail(modName, modVersion, filename));
+                        }
+                        catch (Exception)
+                        {
+                            MelonLogger.Msg("Failed to read assembly " + filename);
+                        }
                     }
                 }
+                MelonLogger.Msg("Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
+                runOnce = true;
             }
-
-            MelonLogger.Msg("Found " + installedMods.Count + " unique non-dev mods installed");
-        }
+        }  
 
         private static string GetNewModName(string currentName)
         {
@@ -233,28 +242,100 @@ namespace VRCModUpdater.Core
 
         private static void DownloadAndUpdateMods()
         {
+            List<ModDetail> toMods = new List<ModDetail>();
+            List<ModDetail> toBroken = new List<ModDetail>();
             List<ModDetail> toUpdate = new List<ModDetail>();
 
-            // List all installed mods that can be updated
-            foreach (KeyValuePair<string, ModDetail> installedMod in installedMods)
+            // Check for broken mods with updates
+            foreach (KeyValuePair<string, ModDetail> brokenMod in brokenMods)
             {
-                VersionUtils.VersionData installedModVersion = VersionUtils.GetVersion(installedMod.Value.version);
-                foreach (KeyValuePair<string, ModDetail> remoteMod in remoteMods)
+                if (remoteMods.TryGetValue(brokenMod.Key, out ModDetail remoteMod))
                 {
-                    if (installedMod.Key == remoteMod.Key)
-                    {
-                        VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.Value.version);
-                        int compareResult = VersionUtils.CompareVersion(remoteModVersion, installedModVersion);
-                        MelonLogger.Msg("(Mod: " + remoteMod.Key + ") version compare between [remote] " + remoteMod.Value.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
-                        if (compareResult > 0)
-                            toUpdate.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.Value.downloadUrl, remoteMod.Value.hash));
+                    if (remoteMod.approvalStatus != 1)
+                        continue;
 
-                        break;
-                    }
+                    VersionUtils.VersionData brokenModVersion = VersionUtils.GetVersion(brokenMod.Value.version);
+                    VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
+                    int compareResult = VersionUtils.CompareVersion(remoteModVersion, brokenModVersion);
+                    
+                    MelonLogger.Msg("(Broken Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + brokenMod.Value.version + ": " + compareResult);
+                    if (compareResult > 0) // Don't move from broken unless new version > old
+                        toMods.Add(new ModDetail(brokenMod.Key, brokenMod.Value.version, brokenMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    continue;
                 }
             }
 
-            MelonLogger.Msg("Found " + toUpdate.Count + " outdated mods");
+            // List all installed mods that can be updated or moved to broken
+            foreach (KeyValuePair<string, ModDetail> installedMod in installedMods)
+            {
+                if (remoteMods.TryGetValue(installedMod.Key, out ModDetail remoteMod))
+                {
+                    VersionUtils.VersionData installedModVersion = VersionUtils.GetVersion(installedMod.Value.version);
+                    VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
+                    int compareResult = VersionUtils.CompareVersion(remoteModVersion, installedModVersion);
+
+                    if(remoteMod.approvalStatus != 1)
+                    {
+                        MelonLogger.Msg($"(Mod: {installedMod.Key}) Remote Approval Status: Broken/Other - {remoteMod.approvalStatus}");
+                        if (compareResult >= 0) // Don't move to broken if local version is higher than remote
+                            toBroken.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath));
+                        else
+                            MelonLogger.Msg($"Ignoring as local version is higer than remote. Remote: {remoteMod.version}, Local: {installedMod.Value.version}");
+                        continue;
+                    }
+                    MelonLogger.Msg("(Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
+                    if (compareResult > 0)
+                        toUpdate.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    continue;
+                }
+            }
+
+            MelonLogger.Msg("Found " + toUpdate.Count + " outdated mods | " + toBroken.Count + " broken mods | " + toMods.Count + " fixed mods");
+
+            toModsCount = toMods.Count;
+            for (int i = 0; i < toModsCount; ++i)
+            {
+                ModDetail mod = toMods[i];
+                MelonLogger.Warning(mod.name + "Moving to Mods from Broken folder");
+                try
+                {
+                    if (File.Exists(mod.filepath))
+                    {
+                        var newDir = Directory.GetParent(Path.GetDirectoryName(mod.filepath)) + "/" + Path.GetFileName(mod.filepath);       
+                        toUpdate.Add(new ModDetail(mod.name, mod.version, newDir, mod.downloadUrl, mod.hash));
+                        File.Delete(mod.filepath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    MelonLogger.Error("Failed to updated fixed mod" + mod.filepath + ":\n" + e);
+                }
+            }
+
+            toBrokenCount = toBroken.Count;
+            for (int i = 0; i < toBrokenCount; ++i)
+            {
+                ModDetail mod = toBroken[i];
+                MelonLogger.Warning(mod.name + " - Moving to Broken folder");
+                try
+                {
+                    if (File.Exists(mod.filepath))
+                    {
+                        var newDir = Path.GetDirectoryName(mod.filepath) + "/Broken";
+                        if(!Directory.Exists(newDir))
+                            Directory.CreateDirectory(newDir);
+                        var newFilePath = newDir + "/" + Path.GetFileName(mod.filepath);
+                        if (!File.Exists(newFilePath))
+                            File.Move(mod.filepath, newFilePath);
+                        else
+                            File.Delete(mod.filepath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    MelonLogger.Error("Failed to move mod to broken folder" + mod.filepath + ":\n" + e);
+                }
+            }
 
             toUpdateCount = toUpdate.Count;
             for (int i = 0; i < toUpdateCount; ++i)

--- a/Core/VRCModUpdaterCore.cs
+++ b/Core/VRCModUpdaterCore.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
+using System.Reflection;
 using VRCModUpdater.API;
 using VRCModUpdater.Core.Externs;
 using VRCModUpdater.Core.Utils;
@@ -36,18 +37,19 @@ namespace VRCModUpdater.Core
         private static int tmpProgressTotal = 0, tmpProgressDownload = 0;
 
         private static int toUpdateCount = 0;
-        private static int toBrokenCount = 0;
-        private static int toModsCount = 0;
 
         private static List<FailedUpdateInfo> failedUpdates = new List<FailedUpdateInfo>();
 
-        private static MelonPreferences_Entry<bool> toFromBroken;
+        private static MelonPreferences_Entry<bool> toFromBroken, resolveDependencies, resolveOptionalDependencies;
 
         public static void Start()
         {
             var prefCategory = MelonPreferences.CreateCategory("VRCModUpdater");
             var diplayTimeEntry = prefCategory.CreateEntry("displaytime", postUpdateDisplayDuration, "Display time (seconds)");
             toFromBroken = prefCategory.CreateEntry("toFromBroken", true, "Attempt to move mods to and from Broken mods folder based on status in Remote API");
+            resolveDependencies = prefCategory.CreateEntry("resolveDependencies", true, "Attempt to download missing required dependencies");
+            resolveOptionalDependencies = prefCategory.CreateEntry("resolveOptionalDependencies", false, "Also attempt to download missing OPTIONAL dependencies");
+
             if (float.TryParse(diplayTimeEntry.GetValueAsString(), out float diplayTime))
                 postUpdateDisplayDuration = diplayTime;
 
@@ -159,8 +161,10 @@ namespace VRCModUpdater.Core
 
         private static void ScanModFolder()
         {
-            var list = new [] { installedMods, brokenMods };
+            var list = new[] { installedMods, brokenMods };
             var runOnce = false;
+            var allDepList = new List<string>();
+            var allOptDepList = new List<string>();
             foreach (var dict in list)
             {   //This is a kinda dirty way to do this
                 dict.Clear();
@@ -183,6 +187,8 @@ namespace VRCModUpdater.Core
                         {
                             string modName;
                             string modVersion;
+                            string[] optDependencies = new string[0];
+
                             using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(filename, new ReaderParameters { ReadWrite = true }))
                             {
 
@@ -194,6 +200,36 @@ namespace VRCModUpdater.Core
 
                                 modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
                                 modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
+
+                            }
+
+                            List<string> depList = new List<string>();
+                            if (resolveDependencies.Value)
+                            {
+                                Assembly modAssembly = Assembly.Load(File.ReadAllBytes(filename)); //Only part about all of this I am suss about
+
+                                MelonOptionalDependenciesAttribute optionals = (MelonOptionalDependenciesAttribute)Attribute.GetCustomAttribute(modAssembly, typeof(MelonOptionalDependenciesAttribute));
+
+                                foreach (AssemblyName dependency in modAssembly.GetReferencedAssemblies())
+                                {
+                                    var depName = GetNewModName(dependency.Name);
+                                    if (remoteMods.ContainsKey(depName))
+                                    {//If dep is in RemoteAPI
+                                        if (!optionals?.AssemblyNames?.Contains(dependency.Name) ?? true) //Sum up all the deps
+                                        {
+                                            if (!allDepList.Contains(depName)) allDepList.Add(depName);
+                                        }
+                                        else
+                                        {
+                                            if (!allDepList.Contains(depName) && !allOptDepList.Contains(depName)) allOptDepList.Add(depName);
+                                        }
+                                        
+                                        if (resolveOptionalDependencies.Value || (!optionals?.AssemblyNames?.Contains(dependency.Name) ?? true))
+                                        {//If we want to add optional deps OR it's not in the optional dep list)
+                                            depList.Add(depName);
+                                        }
+                                    }
+                                }
                             }
 
                             modName = GetNewModName(modName); // Backward mod compatibility
@@ -209,24 +245,41 @@ namespace VRCModUpdater.Core
                                 {
                                     File.Delete(installedModDetail.filepath); // Delete duplicated mods
                                     MelonLogger.Msg("Deleted duplicated mod " + modName);
-                                    dict[modName] = new ModDetail(modName, modVersion, filename);
+                                    dict[modName] = new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies);
                                 }
 
                                 continue;
                             }
 
-                            dict.Add(modName, new ModDetail(modName, modVersion, filename));
+                            dict.Add(modName, new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies));
                         }
-                        catch (Exception)
+                        catch (Exception ex)
                         {
-                            MelonLogger.Msg("Failed to read assembly " + filename);
+                            MelonLogger.Msg("Failed to read assembly " + filename + "\n" + ex.ToString());
                         }
                     }
                 }
-                MelonLogger.Msg("Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
+                MelonLogger.Msg(ConsoleColor.DarkCyan, "Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
                 runOnce = true;
             }
-        }  
+            
+            if (resolveDependencies.Value)
+            { //Just some stats
+                string depString, optDepString;
+                if (allDepList.Count > 0)
+                    depString = string.Join(", ", allDepList);
+                else
+                    depString = "N/A";
+                if (allOptDepList.Count > 0)
+                    optDepString = string.Join(", ", allOptDepList);
+                else
+                    optDepString = "N/A";
+
+                MelonLogger.Msg(ConsoleColor.DarkCyan, $"Found {allDepList.Count} required dependencies: '{depString}' " +
+                    $"and {allOptDepList.Count} optional dependencies: '{optDepString}' used by the mods in your mod folders.\n" +
+                    $"{(resolveOptionalDependencies.Value ? "Both Required and Optional dependencies" : "Only Required dependencies")} will be downloaded, you can change this in Mod Settings");
+            }
+        }
 
         private static string GetNewModName(string currentName)
         {
@@ -244,9 +297,10 @@ namespace VRCModUpdater.Core
 
         private static void DownloadAndUpdateMods()
         {
-            List<ModDetail> toMods = new List<ModDetail>();
-            List<ModDetail> toBroken = new List<ModDetail>();
-            List<ModDetail> toUpdate = new List<ModDetail>();
+            Dictionary<string, ModDetail> toMods = new Dictionary<string, ModDetail>();
+            Dictionary<string, ModDetail> toBroken = new Dictionary<string, ModDetail>();
+            Dictionary<string, ModDetail> toUpdate = new Dictionary<string, ModDetail>();
+            Dictionary<string, ModDetail> checkDeps = new Dictionary<string, ModDetail>();
 
             // Check for broken mods with updates
             foreach (KeyValuePair<string, ModDetail> brokenMod in brokenMods)
@@ -259,10 +313,13 @@ namespace VRCModUpdater.Core
                     VersionUtils.VersionData brokenModVersion = VersionUtils.GetVersion(brokenMod.Value.version);
                     VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
                     int compareResult = VersionUtils.CompareVersion(remoteModVersion, brokenModVersion);
-                    
+
                     MelonLogger.Msg("(Broken Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + brokenMod.Value.version + ": " + compareResult);
                     if (compareResult > 0) // Don't move from broken unless new version > old
-                        toMods.Add(new ModDetail(brokenMod.Key, brokenMod.Value.version, brokenMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    {
+                        toMods.Add(brokenMod.Key, new ModDetail(brokenMod.Key, brokenMod.Value.version, brokenMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                        checkDeps.Add(brokenMod.Key, brokenMod.Value);
+                    }
                     continue;
                 }
             }
@@ -276,146 +333,168 @@ namespace VRCModUpdater.Core
                     VersionUtils.VersionData remoteModVersion = VersionUtils.GetVersion(remoteMod.version);
                     int compareResult = VersionUtils.CompareVersion(remoteModVersion, installedModVersion);
 
-                    if(remoteMod.approvalStatus != 1)
+                    if (remoteMod.approvalStatus != 1)
                     {
                         MelonLogger.Msg($"(Mod: {installedMod.Key}) Remote Approval Status is: Broken/Other - {remoteMod.approvalStatus}");
                         if (compareResult >= 0) // Don't move to broken if local version is higher than remote
-                            toBroken.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath));
+                            toBroken.Add(installedMod.Key, new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath));
                         else
                             MelonLogger.Msg($"Ignoring as local version is higer than remote. Remote: {remoteMod.version}, Local: {installedMod.Value.version}");
                         continue;
                     }
                     MelonLogger.Msg("(Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
                     if (compareResult > 0)
-                        toUpdate.Add(new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                        toUpdate.Add(installedMod.Key, new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
+                    checkDeps.Add(installedMod.Key, installedMod.Value);
                     continue;
                 }
             }
 
-            MelonLogger.Msg("Found " + toUpdate.Count + " outdated mods | " + toBroken.Count + " broken mods | " + toMods.Count + " fixed mods");
+            MelonLogger.Msg(ConsoleColor.DarkCyan, "Found " + toUpdate.Count + " outdated mods | " + toBroken.Count + " broken mods | " + toMods.Count + " fixed mods");
 
-            if (toFromBroken.Value)
+            if (resolveDependencies.Value)
             {
-                toModsCount = toMods.Count;
-                for (int i = 0; i < toModsCount; ++i)
-                {
-                    ModDetail mod = toMods[i];
-                    MelonLogger.Warning(mod.name + " - Moving to Mods from Broken folder");
-                    try
+                foreach (var modtoCheck in checkDeps)
+                {//Check all installed mods
+                    foreach (var dep in modtoCheck.Value.dependencies)
                     {
-                        if (File.Exists(mod.filepath))
-                        {
-                            var newDir = Directory.GetParent(Path.GetDirectoryName(mod.filepath)) + "/" + Path.GetFileName(mod.filepath);
-                            toUpdate.Add(new ModDetail(mod.name, mod.version, newDir, mod.downloadUrl, mod.hash));
-                            File.Delete(mod.filepath);
+                        if (!installedMods.ContainsKey(dep) && !toMods.ContainsKey(dep) && !toUpdate.ContainsKey(dep) && !brokenMods.ContainsKey(dep))
+                        {//If dep is not in Installed Mods, & it is not being added to Mods from Broken, & it isn't already in toUpdate, & it isn't in the broken mods folder
+                         //Dont want to install it twice... or more
+                            if (remoteMods.TryGetValue(dep, out ModDetail remoteDep))
+                            {
+                                if (remoteDep.approvalStatus != 1) //Dont add broken deps
+                                    continue; 
+                                var newFileName = remoteDep.downloadUrl.Split('/').Last();
+                                var newPath = "Mods/" + newFileName; 
+                                MelonLogger.Warning($"Adding Dependency '{newPath}' for Mod '{modtoCheck.Value.name}'");
+                                toUpdate.Add(remoteDep.name, new ModDetail(remoteDep.name, remoteDep.version, newPath, remoteDep.downloadUrl, remoteDep.hash));
+                            }
                         }
-                    }
-                    catch (Exception e)
-                    {
-                        MelonLogger.Error("Failed to updated fixed mod" + mod.filepath + ":\n" + e);
-                    }
-                }
-
-                toBrokenCount = toBroken.Count;
-                for (int i = 0; i < toBrokenCount; ++i)
-                {
-                    ModDetail mod = toBroken[i];
-                    MelonLogger.Warning(mod.name + " - Moving to Broken folder");
-                    try
-                    {
-                        if (File.Exists(mod.filepath))
-                        {
-                            var newDir = Path.GetDirectoryName(mod.filepath) + "/Broken";
-                            if (!Directory.Exists(newDir))
-                                Directory.CreateDirectory(newDir);
-                            var newFilePath = newDir + "/" + Path.GetFileName(mod.filepath);
-                            if (!File.Exists(newFilePath))
-                                File.Move(mod.filepath, newFilePath);
-                            else
-                                File.Delete(mod.filepath);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        MelonLogger.Error("Failed to move mod to broken folder" + mod.filepath + ":\n" + e);
                     }
                 }
             }
 
-            toUpdateCount = toUpdate.Count;
-            for (int i = 0; i < toUpdateCount; ++i)
+            if (toFromBroken.Value)
             {
-                ModDetail mod = toUpdate[i];
-
-                MelonLogger.Msg("Updating " + mod.name);
-                progressTotal = (int)(i / (double)toUpdateCount * 100);
-                currentStatus = $"Updating {mod.name} ({i + 1} / {toUpdateCount})...";
-
-                try
+                foreach (KeyValuePair<string, ModDetail> mod in toMods)
                 {
-                    bool errored = false;
-                    using (var client = new WebClient())
+                    MelonLogger.Warning(mod.Value.name + " - Moving to Mods from Broken folder");
+                    try
                     {
-                        bool downloading = true;
-                        byte[] downloadedFileData = null;
-                        client.DownloadDataCompleted += (sender, e) =>
+                        if (File.Exists(mod.Value.filepath))
                         {
-                            if (e.Error != null)
-                            {
-                                MelonLogger.Error("Failed to update " + mod.name + ":\n" + e.Error);
-                                errored = true;
-                                failedUpdates.Add(new FailedUpdateInfo(mod, FailedUpdateReason.DownloadError, e.ToString()));
-                            }
-                            else
-                                downloadedFileData = e.Result;
+                            var newDir = Directory.GetParent(Path.GetDirectoryName(mod.Value.filepath)) + "/" + Path.GetFileName(mod.Value.filepath);
+                            toUpdate.Add(mod.Key, new ModDetail(mod.Key, mod.Value.version, newDir, mod.Value.downloadUrl, mod.Value.hash));
+                            File.Delete(mod.Value.filepath);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        MelonLogger.Error("Failed to updated fixed mod" + mod.Value.filepath + ":\n" + e);
+                    }
+                }
 
-                            progressDownload = 100;
-                            downloading = false;
-                        };
-                        client.DownloadProgressChanged += (sender, e) =>
+                foreach (KeyValuePair<string, ModDetail> mod in toBroken)
+                {
+                    {
+                        MelonLogger.Warning(mod.Value.name + " - Moving to Broken folder");
+                        try
                         {
-                            progressDownload = e.ProgressPercentage;
-                        };
-                        client.DownloadDataAsync(new Uri(mod.downloadUrl));
-
-                        while (downloading)
-                            Thread.Sleep(50);
-
-                        if (!errored)
+                            if (File.Exists(mod.Value.filepath))
+                            {
+                                var newDir = Path.GetDirectoryName(mod.Value.filepath) + "/Broken";
+                                if (!Directory.Exists(newDir))
+                                    Directory.CreateDirectory(newDir);
+                                var newFilePath = newDir + "/" + Path.GetFileName(mod.Value.filepath);
+                                if (!File.Exists(newFilePath))
+                                    File.Move(mod.Value.filepath, newFilePath);
+                                else
+                                    File.Delete(mod.Value.filepath);
+                            }
+                        }
+                        catch (Exception e)
                         {
-                            string downloadedHash = ComputeSha256Hash(downloadedFileData);
-                            MelonLogger.Msg("Downloaded file hash: " + downloadedHash);
-
-                            if (downloadedHash == mod.hash)
-                            {
-                                try
-                                {
-                                    File.WriteAllBytes(mod.filepath, downloadedFileData);
-                                }
-                                catch (Exception e)
-                                {
-                                    MelonLogger.Error("Failed to save " + mod.filepath + ":\n" + e);
-                                    failedUpdates.Add(new FailedUpdateInfo(mod, FailedUpdateReason.SaveError, e.ToString()));
-                                }
-
-                            }
-                            else
-                            {
-                                MelonLogger.Error("Downloaded file hash mismatches database hash!");
-                                failedUpdates.Add(new FailedUpdateInfo(mod, FailedUpdateReason.HashMismatch, $"Expected hash: {mod.hash}, Downloaded file hash: {downloadedHash}"));
-                            }
+                            MelonLogger.Error("Failed to move mod to broken folder" + mod.Value.filepath + ":\n" + e);
                         }
                     }
                 }
-                catch (Exception e)
-                {
-                    MelonLogger.Error("Failed to update " + mod.filepath + ":\n" + e);
-                    failedUpdates.Add(new FailedUpdateInfo(mod, FailedUpdateReason.Unknown, e.ToString()));
-                }
 
-                progressTotal = (int)((i + 1) / (double)toUpdateCount * 100);
-                MelonLogger.Msg($"Progress: {i + 1}/{toUpdateCount} -> {progressTotal}%");
-;            }
+                toUpdateCount = toUpdate.Count;
+                int i = 0;
+                foreach (KeyValuePair<string, ModDetail> mod in toUpdate)
+                {
+                    MelonLogger.Msg("Updating " + mod.Value.name);
+                    progressTotal = (int)(i / (double)toUpdateCount * 100);
+                    currentStatus = $"Updating {mod.Value.name} ({i + 1} / {toUpdateCount})...";
+
+                    try
+                    {
+                        bool errored = false;
+                        using (var client = new WebClient())
+                        {
+                            bool downloading = true;
+                            byte[] downloadedFileData = null;
+                            client.DownloadDataCompleted += (sender, e) =>
+                            {
+                                if (e.Error != null)
+                                {
+                                    MelonLogger.Error("Failed to update " + mod.Value.name + ":\n" + e.Error);
+                                    errored = true;
+                                    failedUpdates.Add(new FailedUpdateInfo(mod.Value, FailedUpdateReason.DownloadError, e.ToString()));
+                                }
+                                else
+                                    downloadedFileData = e.Result;
+
+                                progressDownload = 100;
+                                downloading = false;
+                            };
+                            client.DownloadProgressChanged += (sender, e) =>
+                            {
+                                progressDownload = e.ProgressPercentage;
+                            };
+                            client.DownloadDataAsync(new Uri(mod.Value.downloadUrl));
+
+                            while (downloading)
+                                Thread.Sleep(50);
+
+                            if (!errored)
+                            {
+                                string downloadedHash = ComputeSha256Hash(downloadedFileData);
+                                MelonLogger.Msg("Downloaded file hash: " + downloadedHash);
+
+                                if (downloadedHash == mod.Value.hash)
+                                {
+                                    try
+                                    {
+                                        File.WriteAllBytes(mod.Value.filepath, downloadedFileData);
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        MelonLogger.Error("Failed to save " + mod.Value.filepath + ":\n" + e);
+                                        failedUpdates.Add(new FailedUpdateInfo(mod.Value, FailedUpdateReason.SaveError, e.ToString()));
+                                    }
+
+                                }
+                                else
+                                {
+                                    MelonLogger.Error("Downloaded file hash mismatches database hash!");
+                                    failedUpdates.Add(new FailedUpdateInfo(mod.Value, FailedUpdateReason.HashMismatch, $"Expected hash: {mod.Value.hash}, Downloaded file hash: {downloadedHash}"));
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        MelonLogger.Error("Failed to update " + mod.Value.filepath + ":\n" + e);
+                        failedUpdates.Add(new FailedUpdateInfo(mod.Value, FailedUpdateReason.Unknown, e.ToString()));
+                    }
+
+                    progressTotal = (int)((i + 1) / (double)toUpdateCount * 100);
+                    MelonLogger.Msg($"Progress: {i + 1}/{toUpdateCount} -> {progressTotal}%");
+                    i++;
+                }
+            }
         }
     }
 }

--- a/Core/VRCModUpdaterCore.cs
+++ b/Core/VRCModUpdaterCore.cs
@@ -8,14 +8,12 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
-using System.Reflection;
 using System.Windows.Forms;
 using VRCModUpdater.API;
 using VRCModUpdater.Core.API;
 using VRCModUpdater.Core.Externs;
 using VRCModUpdater.Core.Utils;
 using Winuser;
-using Newtonsoft.Json.Linq;
 
 namespace VRCModUpdater.Core
 {
@@ -38,16 +36,13 @@ namespace VRCModUpdater.Core
         public static string currentStatus = "", tmpCurrentStatus = "";
         public static int progressTotal = 0, progressDownload = 0;
         private static int tmpProgressTotal = 0, tmpProgressDownload = 0;
-        
+
         private static int toUpdateCount = 0;
         private static string msg;
 
         private static List<FailedUpdateInfo> failedUpdates = new List<FailedUpdateInfo>();
 
         private static MelonPreferences_Entry<bool> toFromBroken, resolveDependencies, resolveOptionalDependencies, popUpMsg;
-
-        private static string modJsonPath = "UserData/ModsFolder.json";
-        private static string brokemodJsonPath = "UserData/ModsFolder-Broken.json";
 
         public static void Start()
         {
@@ -57,9 +52,6 @@ namespace VRCModUpdater.Core
             resolveDependencies = prefCategory.CreateEntry("resolveDependencies", true, "Attempt to download missing required dependencies");
             resolveOptionalDependencies = prefCategory.CreateEntry("resolveOptionalDependencies", false, "Also attempt to download missing OPTIONAL dependencies");
             popUpMsg = prefCategory.CreateEntry("popUpMsg", true, "Display pop up messsage box if mods are updated or moved to/from broken");
-
-            resolveDependencies.OnValueChanged += OnResolveChange;
-            resolveOptionalDependencies.OnValueChanged += OnResolveChange;
 
             if (float.TryParse(diplayTimeEntry.GetValueAsString(), out float diplayTime))
                 postUpdateDisplayDuration = diplayTime;
@@ -166,141 +158,29 @@ namespace VRCModUpdater.Core
                 if (versionDetails.approvalStatus == 1)
                     verifiedModsCount++;
             }
-            
+
             MelonLogger.Msg("API returned " + apiMods.Length + " mods, including " + verifiedModsCount + " verified mods");
-        }
-
-        private static Dictionary<string, ModDetail> LoadJson(string path)
-        {
-            var modList = new Dictionary<string, ModDetail>();
-            if (!File.Exists(path))
-            {
-                File.WriteAllText(path, "[]");
-                MelonLogger.Msg($"{path} not found. Creating new one...");
-            }
-            else
-            {
-                string text = File.ReadAllText(path);
-                if (string.IsNullOrWhiteSpace(text))
-                {
-                    File.WriteAllText(path, "[]");
-                    MelonLogger.Msg($"{path} is empty. Creating new one...");
-                }
-                else
-                {
-                    try
-                    {
-                        JArray array = JArray.Parse(text);
-                        foreach (JToken token in array)
-                        {
-                            var mod = JObject.Parse(token.ToString()).ToObject<ModDetail>();
-                            modList.Add(mod.name, mod);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        MelonLogger.Error("Something went wrong while parsing the json file. Deleting and ignoring for this run\n" + ex.ToString());
-                        File.WriteAllText(path, "[]");
-                        modList.Clear();
-                        return modList;
-                    }
-                }
-            }
-            return modList;
-        }
-
-        private static void OnResolveChange(bool oldValue, bool newValue)
-        {
-            if (oldValue == newValue) return;
-            File.WriteAllText(modJsonPath, "[]");
-            File.WriteAllText(brokemodJsonPath, "[]");
-            MelonLogger.Msg($"Resolve Dependancy option changed, clearing cache files");
-        }
-
-        private static bool PreScanModFolder()
-        {
-            installedMods = LoadJson(modJsonPath);
-            brokenMods = LoadJson(brokemodJsonPath);
-
-            var list = new[] { installedMods, brokenMods };
-            var runOnce = false;
-            foreach (var dict in list)
-            {
-                string basedirectory = !runOnce ? MelonHandler.ModsDirectory : MelonHandler.ModsDirectory + "\\Broken";
-                if (!Directory.Exists(basedirectory))
-                    continue;
-                string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
-                if (dlltbl.Length > 0)
-                {
-                    for (int i = 0; i < dlltbl.Length; i++)
-                    {
-                        string filename = dlltbl[i];
-                        if (string.IsNullOrEmpty(filename))
-                            continue;
-
-                        if (filename.EndsWith(".dev.dll"))
-                            continue;
-
-                        var fileFound = false;
-                        for (int j = 0; j < dict.Count; j++)
-                        { //Checking if this file exists in previous mod list
-                            //MelonLogger.Msg($"filename {filename} comp to {dict.ElementAt(j).Value.filepath}");
-                            if (dict.ElementAt(j).Value.filepath == filename)
-                            {
-                                if(dict.ElementAt(j).Value.lastMod == File.GetLastWriteTime(filename) && dict.ElementAt(j).Value.lastAccess == File.GetLastAccessTime(filename))
-                                { //Checking if the file has been modified or accessed since last check
-                                    fileFound = true;
-                                    break;
-                                }
-                                else
-                                {
-                                    MelonLogger.Msg($"Mod has been modified or accessed since last check. Will load mod metadata from disk instead of using cached\nMod: {filename}");
-                                    return false;
-                                }
-                            }
-                        }
-                        if (!fileFound) //If file was not found in previous mod list, return false and scan
-                        {
-                            MelonLogger.Msg($"Mod found that was not in cache. Will load mod metadata from disk instead of using cached\nMod: {filename}");
-                            return false;
-                        }
-                    }
-                }
-                runOnce = true;
-            }
-            return true;
         }
 
         private static void ScanModFolder()
         {
-            if (PreScanModFolder())
-            {
-                var modCount = 0;
-                var brokeCount = 0;
-                MelonLogger.Msg(ConsoleColor.Cyan, "Using cached mod list");
-                foreach (var mod in installedMods)
+            var list = new[] { installedMods, brokenMods };
+            var runOnce = false;
+            var allDepList = new List<string>();
+            var allOptDepList = new List<string>();
+            foreach (var dict in list)
+            {   //This is a kinda dirty way to do this
+                dict.Clear();
+
+                string modsFolder = MelonHandler.ModsDirectory;
+                string desktopFolder = $"{modsFolder}/Desktop";
+                string vrFolder = $"{modsFolder}/VR";
+
+                string[] folders = new string[3]{ modsFolder,desktopFolder,vrFolder};
+
+                foreach (string folder in folders)
                 {
-                    MelonLogger.Msg("Cached mod: " + mod.Key);
-                    modCount++;
-                }
-                foreach (var mod in brokenMods)
-                {
-                    MelonLogger.Msg("Cached broken mod: " + mod.Key);
-                    brokeCount++;
-                }
-                MelonLogger.Msg(ConsoleColor.Cyan, "Loading " + modCount + " cached unique non-dev mods and " + + brokeCount + " in Broken folder");
-            }
-            else
-            {
-                MelonLogger.Msg(ConsoleColor.DarkCyan, "Loading mods from disk");
-                var list = new[] { installedMods, brokenMods };
-                var runOnce = false;
-                var allDepList = new List<string>();
-                var allOptDepList = new List<string>();
-                foreach (var dict in list)
-                {   //This is a kinda dirty way to do this
-                    dict.Clear();
-                    string basedirectory = !runOnce ? MelonHandler.ModsDirectory : MelonHandler.ModsDirectory + "\\Broken";
+                    string basedirectory = !runOnce ? folder : folder + "/Broken";
                     if (!Directory.Exists(basedirectory))
                         continue;
                     string[] dlltbl = Directory.GetFiles(basedirectory, "*.dll");
@@ -333,7 +213,7 @@ namespace VRCModUpdater.Core
 
                                     modName = melonInfoAttribute.ConstructorArguments[1].Value as string;
                                     modVersion = melonInfoAttribute.ConstructorArguments[2].Value as string;
-                                    
+
                                     if (resolveDependencies.Value)
                                     {
                                         var optionals = new List<string>();
@@ -344,7 +224,7 @@ namespace VRCModUpdater.Core
                                             foreach (var item in melonOptDepend.ConstructorArguments[0].Value as IEnumerable<CustomAttributeArgument>)
                                             {
                                                 optionals.Add(item.Value.ToString());
-                                            }   
+                                            }
                                         }
 
                                         var references = assembly.MainModule.AssemblyReferences;
@@ -386,12 +266,12 @@ namespace VRCModUpdater.Core
                                     {
                                         File.Delete(installedModDetail.filepath); // Delete duplicated mods
                                         MelonLogger.Msg("Deleted duplicated mod " + modName);
-                                        dict[modName] = new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies, File.GetLastWriteTime(filename), File.GetLastAccessTime(filename));
+                                        dict[modName] = new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies);
                                     }
 
                                     continue;
                                 }
-                                dict.Add(modName, new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies, File.GetLastWriteTime(filename), File.GetLastAccessTime(filename)));
+                                dict.Add(modName, new ModDetail(modName, modVersion, filename, depList.ToArray(), optDependencies));
                             }
                             catch (Exception ex)
                             {
@@ -399,32 +279,27 @@ namespace VRCModUpdater.Core
                             }
                         }
                     }
-                    MelonLogger.Msg(ConsoleColor.DarkCyan, "Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
-
-                    if (!runOnce)
-                        File.WriteAllText(modJsonPath, JsonConvert.SerializeObject(dict.Values, Formatting.Indented));
-                    else
-                        File.WriteAllText(brokemodJsonPath, JsonConvert.SerializeObject(dict.Values, Formatting.Indented));
-
-                    runOnce = true;
                 }
+                MelonLogger.Msg(ConsoleColor.DarkCyan, "Found " + dict.Count + " unique non-dev mods " + $"{(!runOnce ? "installed" : "in Broken folder")}");
 
-                if (resolveDependencies.Value)
-                { //Just some stats
-                    string depString, optDepString;
-                    if (allDepList.Count > 0)
-                        depString = string.Join(", ", allDepList);
-                    else
-                        depString = "N/A";
-                    if (allOptDepList.Count > 0)
-                        optDepString = string.Join(", ", allOptDepList);
-                    else
-                        optDepString = "N/A";
+                runOnce = true;
+            }
 
-                    MelonLogger.Msg(ConsoleColor.DarkCyan, $"Found {allDepList.Count} required dependencies: '{depString}' " +
-                        $"and {allOptDepList.Count} optional dependencies: '{optDepString}' used by the mods in your mod folders.\n" +
-                        $"{(resolveOptionalDependencies.Value ? "Both Required and Optional dependencies" : "Only Required dependencies")} will be downloaded, you can change this in Mod Settings");
-                }
+            if (resolveDependencies.Value)
+            { //Just some stats
+                string depString, optDepString;
+                if (allDepList.Count > 0)
+                    depString = string.Join(", ", allDepList);
+                else
+                    depString = "N/A";
+                if (allOptDepList.Count > 0)
+                    optDepString = string.Join(", ", allOptDepList);
+                else
+                    optDepString = "N/A";
+
+                MelonLogger.Msg(ConsoleColor.DarkCyan, $"Found {allDepList.Count} required dependencies: '{depString}' " +
+                    $"and {allOptDepList.Count} optional dependencies: '{optDepString}' used by the mods in your mod folders.\n" +
+                    $"{(resolveOptionalDependencies.Value ? "Both Required and Optional dependencies" : "Only Required dependencies")} will be downloaded, you can change this in Mod Settings");
             }
         }
 
@@ -502,11 +377,11 @@ namespace VRCModUpdater.Core
                     }
                     MelonLogger.Msg("(Mod: " + remoteMod.name + ") version compare between [remote] " + remoteMod.version + " and [local] " + installedMod.Value.version + ": " + compareResult);
                     if (compareResult > 0)
-                    { 
+                    {
                         toUpdate.Add(installedMod.Key, new ModDetail(installedMod.Key, installedMod.Value.version, installedMod.Value.filepath, remoteMod.downloadUrl, remoteMod.hash));
                         updateList.Add("   " + installedMod.Key);
                     }
-                    if(!checkDeps.ContainsKey(installedMod.Key)) checkDeps.Add(installedMod.Key, installedMod.Value);
+                    if (!checkDeps.ContainsKey(installedMod.Key)) checkDeps.Add(installedMod.Key, installedMod.Value);
                     continue;
                 }
             }
@@ -531,7 +406,7 @@ namespace VRCModUpdater.Core
 
                                     HttpWebRequest request = (HttpWebRequest)WebRequest.Create(remoteDep.downloadUrl); //Get file name, this is needed after api v1 switch to using redirects 
                                     request.AllowAutoRedirect = false;
-                                    request.UserAgent =APIConstants.USER_AGENT;
+                                    request.UserAgent = APIConstants.USER_AGENT;
                                     HttpWebResponse response = (HttpWebResponse)request.GetResponse();
                                     string redirUrl = response.Headers["Location"];
                                     response.Close();
@@ -552,17 +427,17 @@ namespace VRCModUpdater.Core
                 }
             }
 
-            if(popUpMsg.Value && ((updateList.Count > 0) || (depList.Count > 0) || (fromBrokenList.Count > 0) || (toBrokenList.Count > 0)))
+            if (popUpMsg.Value && ((updateList.Count > 0) || (depList.Count > 0) || (fromBrokenList.Count > 0) || (toBrokenList.Count > 0)))
             {
-                msg = 
-                    (updateList.Count > 0 ? "Downloading updates for:\n" + string.Join("\n", updateList) + "\n" : "")  +
-                    (depList.Count > 0 ? "Adding the following mod dependencies:\n" + string.Join("\n", depList) + "\n" : "")  +
-                    (fromBrokenList.Count > 0 ? "Moving from the broken folder:\n" + string.Join("\n", fromBrokenList) + "\n" : "")  +
+                msg =
+                    (updateList.Count > 0 ? "Downloading updates for:\n" + string.Join("\n", updateList) + "\n" : "") +
+                    (depList.Count > 0 ? "Adding the following mod dependencies:\n" + string.Join("\n", depList) + "\n" : "") +
+                    (fromBrokenList.Count > 0 ? "Moving from the broken folder:\n" + string.Join("\n", fromBrokenList) + "\n" : "") +
                     (toBrokenList.Count > 0 ? "Moving to the broken folder:\n" + string.Join("\n", toBrokenList) : "");
-                
+
                 new Thread(new ThreadStart(SpawnMessage)).Start();
             }
-            
+
 
             if (toFromBroken.Value)
             {
@@ -686,7 +561,7 @@ namespace VRCModUpdater.Core
                 }
             }
         }
-        
+
         private static void SpawnMessage()
         {
             if (msg != null)


### PR DESCRIPTION
### Bug fixes

Dependency Resolver has been changed to check for redirect URL and get the file name from that, this is needed with the change to API v1
https://github.com/Nirv-git/VRCModUpdater/blob/b65dcf99f715a3091f1c243da1a570cbb93fe9a1/Core/VRCModUpdaterCore.cs#L532

Dependency Resolver would previously prevent newly updated mods from loading till next reload, uses silly Ceil stuff now to fix that
https://github.com/Nirv-git/VRCModUpdater/blob/b65dcf99f715a3091f1c243da1a570cbb93fe9a1/Core/VRCModUpdaterCore.cs#L337

### Popup
Now has a popup to list what was changed, disableable in Mod Settings

### Caching
Now can cache your local mod folders for quicker loading, hopefully. Added this since randomly for me at least it can take a bit to scan the mods folder. (I blame AV maybe?)

![image](https://user-images.githubusercontent.com/81605232/173667553-25f0f927-010b-438c-af9e-308db0c682e9.png)

