### PR TITLE
Add support for ModLoadSeparator

### DIFF
--- a/Loader/Properties/AssemblyInfo.cs
+++ b/Loader/Properties/AssemblyInfo.cs
@@ -35,3 +35,7 @@ using VRCModUpdater.Loader;
 
 [assembly: MelonInfo(typeof(VRCModUpdaterPlugin), "VRCModUpdater.Loader", VRCModUpdaterPlugin.VERSION, "Slaynash")]
 [assembly: MelonGame("VRChat", "VRChat")]
+
+// ModLoadSeparator runs before us and we need to be first, otherwise it tries loading mods that 
+// we may have moved to the Broken folder
+[assembly: MelonPriority(int.MinValue)]


### PR DESCRIPTION
This just adds basic support for the Desktop and VR folders created by ModLoadSeparator

All functionality works, creates localized Broken folders and properly moves things back to the VR/Desktop folders when it's no longer broken, updates also work as expected